### PR TITLE
Link GitHub issues from docs to reduce duplicate tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,11 @@ This IG may propose becoming a Working Group if:
 
 ## Work Tracking
 
-| Item | Status | Champion | Notes |
-| :--- | :--- | :--- | :--- |
-| Requirements alignment | In Progress | All facilitators | Review approaches, identify common requirements and gaps |
-| Agent Skills spec coordination | In Progress | Ola | Use [agentskills/agentskills Discussions](https://github.com/agentskills/agentskills/discussions) for intersecting topics; see [contributing guide](https://github.com/agentskills/agentskills/blob/main/CONTRIBUTING.md) |
-| Experimental findings repo | Proposed | Ola | Dedicated repo for implementations and evaluation results |
-| SEP-2076 review | In Progress | Yu Yi | Skills as first-class primitive proposal |
-| Registry skills.json proposal | In Progress | Ozz | Skills metadata in registry schema |
-| MCP Skills Convention v0.1 | Proposed | TBD | Documented pattern (not spec) for skills over existing primitives |
+Work items are tracked as [GitHub Issues](https://github.com/modelcontextprotocol/experimental-ext-skills/issues). Key coordination channels:
+
+- **Agent Skills spec coordination:** Use [agentskills/agentskills Discussions](https://github.com/agentskills/agentskills/discussions) for intersecting topics; see [contributing guide](https://github.com/agentskills/agentskills/blob/main/CONTRIBUTING.md)
+- **SEP-2076 review:** [Skills as first-class primitive proposal](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076) (Champion: Yu Yi)
+- **Registry skills.json proposal:** [Skills metadata in registry schema](https://github.com/modelcontextprotocol/registry/discussions/895) (Champion: Ozz)
 
 ## Success Criteria
 

--- a/docs/approaches.md
+++ b/docs/approaches.md
@@ -60,6 +60,8 @@ Examples:
 - Expose skills via tools like `list_skills` and `read_skills`. Server instructions can direct the agent to call the skill tool first.
 - Expose skills as resources (e.g. skill://...), which can also be exposed through tools
 
+**See also:** [#41](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/41) — Server-side reference implementation, [#55](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/55) — Recommended _meta keys for skill resources
+
 
 **Implementations:** 
 
@@ -97,6 +99,8 @@ Several design considerations have been suggested in community discussion and pr
 - **Git-based distribution:** Versioned distribution via git (tags, pinned refs) can be viable without a formal registry. Clare Liguori (AWS) noted that Terraform operated without a formal registry for a long time — Feb 26 office hours.
 - **Domain-level discovery:** The [Agent Skills Discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc) proposes `/.well-known/skills/` for organizations to publish skills at predictable URLs with content integrity (SHA-256 digests). This is complementary to MCP — it handles discovery and distribution while MCP handles runtime consumption.
 
+**See also:** [#44](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/44) — Define well-known URI schemes and naming patterns for skill resources
+
 **Community input:**
 
 > "Installless/temporary/ephemeral skill availability while server is installed feels like a good pattern. Clients could optionally offer to permanently install." — [Sam Morrow](https://github.com/SamMorrowDrums) (GitHub), via Discord
@@ -112,6 +116,8 @@ Instead of exposing skill tools to the main agent, use MCP's Sampling with Tools
 **Caveat:** Sampling has limited client support currently.
 
 **Source:** [jbnitorum](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076#issuecomment-3806151745)
+
+**See also:** [#42](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/42) — Test skills-via-sampling approach
 
 ## 4. Gateway/Composition Pattern
 
@@ -140,6 +146,8 @@ A documented "MCP Skills Convention" as a middle path between ad-hoc experiments
 - Allow data gathering on adoption before considering protocol-level changes
 
 This mirrors how other ecosystems (e.g., Kubernetes) graduate patterns: start as convention, prove value, then formalize. Could be a concrete IG deliverable: "MCP Skills Convention v0.1."
+
+**See also:** [#43](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/43) — Draft MCP Skills Convention v0.1
 
 **Advantages of the convention approach:**
 

--- a/docs/experimental-findings.md
+++ b/docs/experimental-findings.md
@@ -1,5 +1,7 @@
 # Experimental Findings
 
+> **Contributing findings?** See [#50](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/50) for the contribution template proposal.
+
 ## McpGraph: Skills in MCP Server Repo
 
 **Repo:** [TeamSparkAI/mcpGraph](https://github.com/TeamSparkAI/mcpGraph)
@@ -86,3 +88,5 @@ Multiple community members have independently reported that models do not reliab
 > "Skills are ephemeral and/or time decaying — it clicks once and then give it some time and they lose the plot." — Kryspin (qcompute), via Discord
 
 > "I've seen lazy load skills with various degrees of success, actually looks like it might be model specific… [best pattern is] putting them in with a subagent that similarly named or mentions the topic in their description." — Kryspin (qcompute), via Discord
+
+**See also:** [#37](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/37) — Compare skill delivery mechanisms: file-based vs MCP-based

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -2,6 +2,8 @@
 
 ## 1. Is this a registry problem or an MCP server problem?
 
+> **See also:** [#44](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/44) — Define well-known URI schemes and naming patterns for skill resources
+
 Should skills be discoverable through registry metadata ("if you install this server, also install this skill") or contained within the MCP server itself?
 
 A third option is emerging: domain-level discovery via `/.well-known/skills/` (see [Agent Skills Discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc)). This decouples skill discovery from both registries and MCP servers — an organization publishes skills at a predictable URL on its own domain. This could complement MCP-level discovery rather than replace it: `.well-known` handles "find available skills," MCP handles "load and use them at runtime."
@@ -17,6 +19,8 @@ For more community input on this topic see: (approaches.md#design-principles)
 Or is the separation between "primitive server" and "skill that uses the primitive" the right abstraction?
 
 ## 4. How should skills relate to multiple servers?
+
+> **Tracked in:** [#39](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/39) — Research skill dependency declaration and host-mediated resolution
 
 A skill orchestrating tools from several servers can't live in any single server's instructions.
 
@@ -36,6 +40,9 @@ The agentskills.io spec currently has a freeform [compatibility field](https://a
 
 ## 5. Do clients actually leverage skills when presented via MCP?
 
+> **Tracked in:** [#38](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/38) — Survey client resource-loading support across major MCP clients
+> **See also:** [#37](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/37) — Compare skill delivery mechanisms: file-based vs MCP-based
+
 Early experiments suggest they do, but more rigorous testing is needed.
 
 **Community input:**
@@ -48,9 +55,13 @@ Early experiments suggest they do, but more rigorous testing is needed.
 
 ## 7. What would MCP have had to get right for skills to have been shipped over MCP from the beginning?
 
+> **See also:** [#47](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/47) — Create evaluation matrix mapping approaches to requirements
+
 — [Keith Groves](https://github.com/keithagroves)
 
 ## 8. What could MCP reasonably change so that it will be the obvious choice for new formats?
+
+> **See also:** [#54](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/54) — The case for custom metadata instead of a URI convention
 
 — [Keith Groves](https://github.com/keithagroves)
 
@@ -94,6 +105,8 @@ Note: Some apps like Claude Code have started to indicate in the skill frontmatt
 
 ## 12. Why not just resources?
 
+> **See also:** [#54](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/54) — The case for custom metadata instead of a URI convention, [#55](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/55) — Define recommended _meta keys for skill resources
+
 **Core Maintainer input:**
 
 > "Why not just resources? That feels like the obvious implementation since skills are just files and resources already exist to expose files. i.e. just expose skills as resources the same as they're currently exposed on the filesystem and then just use the existing Agent Skills specification — client can find skills using resources/list to find SKILL.md files." — [Peter Alexander](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076#discussion_r2736299627)
@@ -107,6 +120,9 @@ Note: Some apps like Claude Code have started to indicate in the skill frontmatt
 See also [Approaches](approaches.md) for more notes on using resources.
 
 ## 13. What is the optimal relationship between skills and MCP?
+
+> **Tracked in:** [#43](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/43) — Draft MCP Skills Convention v0.1
+> **See also:** [#47](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/47) — Create evaluation matrix mapping approaches to requirements
 
 Skills already work as simple files that agents load directly. Adding MCP to the process should provide clear value beyond what standalone skills already offer.
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -30,6 +30,8 @@ Skills that leverage tools from multiple off-the-shelf servers where you can't (
 
 Beyond multi-server tool orchestration, skills themselves may be composable — one skill depending on another skill's output or behavior. This extends the dependency model beyond tool availability to skill availability, and raises questions about declarative dependency metadata. See [Open Question 4](open-questions.md#4-how-should-skills-relate-to-multiple-servers) for the emerging proposal on host-mediated dependency resolution.
 
+**See also:** [#39](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/39) — Skill dependency declaration, [#45](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/45) — Worked examples for multi-server composition
+
 ## 4. Progressive Disclosure
 
 Skills broken into linked sets of files for effective context management, loaded progressively as the agent needs them rather than all at once.
@@ -45,6 +47,8 @@ Skills broken into linked sets of files for effective context management, loaded
 > "A server can contain 100s or 1000s of skills as an extreme but a client might only need handful of them." — [Kaxil Naik](https://github.com/kaxil) (Astronomer), via Discord
 
 **Related:** [Anthropic's guidance on progressive disclosure](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)
+
+**See also:** [#45](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/45) — Worked examples for progressive disclosure, [#40](https://github.com/modelcontextprotocol/experimental-ext-skills/issues/40) — Client-side reference implementation for model-driven resource loading
 
 ## 5. Server-Skill Pairing
 


### PR DESCRIPTION
## Summary

- Cross-reference open questions, approaches, use cases, and experimental findings with their corresponding GitHub issues
- Replace the Work Tracking table in README with a link to the issues list, keeping only external coordination links (Agent Skills spec, SEP-2076, Registry proposal)
- Use "Tracked in" for direct 1:1 matches (Q4→#39, Q5→#38, Q13→#43) and "See also" for related work items

## Files changed

- `docs/open-questions.md` — Issue links on 8 of 13 questions
- `README.md` — Work Tracking table → issues list link
- `docs/approaches.md` — See-also links for approaches 3, 6, and distribution considerations
- `docs/use-cases.md` — See-also links for UC3 (multi-server) and UC4 (progressive disclosure)
- `docs/experimental-findings.md` — Contribution template note and skill reliability link

## Not changed

- `related-work.md` (already well-linked)
- `CONTRIBUTING.md`, `problem-statement.md` (no matching issues)
- Questions Q2, Q3, Q9, Q10, Q11 (no dedicated tracking issues exist yet)

🦉 Generated with [Claude Code](https://claude.com/claude-code)