### PR TITLE
Add dynamic MCP server dependency loading (port from skillsdotnet)

### DIFF
--- a/examples/dynamic-server-loading/typescript/README.md
+++ b/examples/dynamic-server-loading/typescript/README.md
@@ -1,0 +1,57 @@
+# Dynamic MCP Server Loading Example
+
+Demonstrates the **skill dependency resolution** pattern — a TypeScript port of the
+[skillsdotnet DynamicMcpServers sample](https://github.com/bradwilson/skillsdotnet/tree/main/samples/DynamicMcpServers).
+
+## How It Works
+
+1. A skill server exposes skills as MCP resources (using the Skills as Resources pattern)
+2. The client builds a `SkillCatalog` that discovers all available skills
+3. Skills can declare MCP server dependencies in their YAML frontmatter:
+   ```yaml
+   dependencies: [everything-server]
+   ```
+4. When a skill with dependencies is loaded via `catalog.loadSkill()`, the catalog fires
+   the `onDependenciesRequired` callback
+5. The client host connects the required MCP servers dynamically
+6. Tools from the newly connected servers become available
+
+## Running
+
+```bash
+# 1. Build the SDK
+cd typescript/sdk && npm install && npm run build
+
+# 2. Build the skill server
+cd examples/skills-as-resources/typescript && npm install && npm run build
+
+# 3. Build and run this example
+cd examples/dynamic-server-loading/typescript
+npm install
+npm run build
+npm start
+```
+
+## Architecture
+
+```
+Client Host (this example)
+  │
+  ├── SkillCatalog
+  │     ├── addClient(skillServer) → discovers skills
+  │     ├── onDependenciesRequired → callback fires when loading skill with deps
+  │     └── loadSkill("explore-everything") → triggers dependency resolution
+  │
+  ├── Skill Server (skills-as-resources)
+  │     └── skill://explore-everything/SKILL.md
+  │           frontmatter: dependencies: [everything-server]
+  │
+  └── Everything Server (connected dynamically)
+        └── echo, add, sampleLLM, ... (tools become available)
+```
+
+## Key Pattern
+
+The client host owns the mapping from server names to connection configs.
+The skill library only communicates server names — it never creates connections itself.
+This keeps the dependency resolution pattern generic and host-agnostic.

--- a/examples/dynamic-server-loading/typescript/package-lock.json
+++ b/examples/dynamic-server-loading/typescript/package-lock.json
@@ -1,0 +1,1748 @@
+{
+  "name": "@skills-over-mcp-ig/dynamic-server-loading-example",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@skills-over-mcp-ig/dynamic-server-loading-example",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ext-modelcontextprotocol/skills": "file:../../../typescript/sdk",
+        "@modelcontextprotocol/sdk": "^1.27.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../../../typescript/sdk": {
+      "name": "@ext-modelcontextprotocol/skills",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "yaml": "^2.7.0"
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@types/node": "^22.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^8.57.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ext-modelcontextprotocol/skills": {
+      "resolved": "../../../typescript/sdk",
+      "link": true
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.0.tgz",
+      "integrity": "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/examples/dynamic-server-loading/typescript/package.json
+++ b/examples/dynamic-server-loading/typescript/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@skills-over-mcp-ig/dynamic-server-loading-example",
+  "version": "0.1.0",
+  "description": "Demonstrates dynamic MCP server loading triggered by skill dependencies",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@ext-modelcontextprotocol/skills": "file:../../../typescript/sdk",
+    "@modelcontextprotocol/sdk": "^1.27.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/examples/dynamic-server-loading/typescript/src/index.ts
+++ b/examples/dynamic-server-loading/typescript/src/index.ts
@@ -1,0 +1,192 @@
+/**
+ * Dynamic MCP Server Loading Example
+ *
+ * Demonstrates the skill dependency resolution pattern:
+ * 1. Connect to a skill server that exposes skills as MCP resources
+ * 2. Build a SkillCatalog that discovers available skills
+ * 3. Set an onDependenciesRequired callback for dynamic server connections
+ * 4. Load a skill with dependencies — the callback fires automatically
+ * 5. The host connects the required MCP server on demand
+ *
+ * This is a TypeScript port of the skillsdotnet DynamicMcpServers sample.
+ * See: https://github.com/bradwilson/skillsdotnet/tree/main/samples/DynamicMcpServers
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SkillCatalog } from "@ext-modelcontextprotocol/skills";
+import type { SkillDependencyRequest } from "@ext-modelcontextprotocol/skills";
+
+// --- Configuration ---
+
+// Server configs the client host knows about. In a real app this might come from
+// a config file, user settings, or a registry. The key point is that the client host
+// owns this mapping — the skill library only communicates server names.
+const serverConfigs: Record<string, { command: string; args: string[] }> = {
+  "everything-server": {
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-everything"],
+  },
+};
+
+// --- Track dynamically connected MCP servers ---
+
+const connectedServers = new Map<string, Client>();
+
+// --- Helper: connect to an MCP server via stdio ---
+
+async function connectServer(
+  name: string,
+  config: { command: string; args: string[] },
+): Promise<Client> {
+  const transport = new StdioClientTransport({
+    command: config.command,
+    args: config.args,
+  });
+
+  const client = new Client({ name, version: "1.0.0" });
+  await client.connect(transport);
+  return client;
+}
+
+// --- Main ---
+
+async function main() {
+  // Determine skill server path (the skills-as-resources example server)
+  const skillServerDir =
+    process.argv[2] ||
+    new URL("../../skills-as-resources/typescript", import.meta.url).pathname;
+
+  console.log("=== Dynamic MCP Server Loading Demo ===\n");
+
+  // 1. Connect to skill server
+  console.log(`[host] Connecting to skill server: ${skillServerDir}`);
+  const skillTransport = new StdioClientTransport({
+    command: "node",
+    args: [
+      `${skillServerDir}/dist/index.js`,
+      "--skills-dir",
+      new URL("../../sample-skills", import.meta.url).pathname,
+    ],
+  });
+
+  const skillClient = new Client({
+    name: "dynamic-server-demo",
+    version: "1.0.0",
+  });
+  await skillClient.connect(skillTransport);
+  console.log("[host] Connected to skill server.\n");
+
+  // 2. Build skill catalog
+  const catalog = await SkillCatalog.create(skillClient);
+  console.log(`[host] Discovered ${catalog.skillNames.length} skill(s):`);
+  for (const name of catalog.skillNames) {
+    console.log(`  - ${name}`);
+  }
+  console.log();
+
+  // 3. Print skill contexts (what gets injected into system prompts)
+  console.log("[host] Skill contexts for system prompt:");
+  for (const ctx of catalog.getSkillContexts()) {
+    console.log(`  ${ctx}`);
+  }
+  console.log();
+
+  // 4. Print tool definition
+  const toolDef = catalog.getLoadSkillToolDefinition();
+  console.log("[host] load_skill tool definition:");
+  console.log(JSON.stringify(toolDef, null, 2));
+  console.log();
+
+  // 5. Set dependency callback
+  catalog.onDependenciesRequired = async (
+    request: SkillDependencyRequest,
+  ): Promise<boolean> => {
+    console.log(
+      `\n[host] Skill '${request.skillName}' requires MCP servers: ${request.serverNames.join(", ")}`,
+    );
+
+    for (const serverName of request.serverNames) {
+      if (connectedServers.has(serverName)) {
+        console.log(`[host] '${serverName}' is already connected.`);
+        continue;
+      }
+
+      const config = serverConfigs[serverName];
+      if (!config) {
+        console.log(
+          `[host] Unknown server '${serverName}' — cannot connect.`,
+        );
+        return false;
+      }
+
+      console.log(`[host] Connecting to '${serverName}'...`);
+      try {
+        const client = await connectServer(serverName, config);
+        connectedServers.set(serverName, client);
+        console.log(`[host] Connected to '${serverName}'.`);
+
+        // List tools from the newly connected server
+        const toolsResult = await client.listTools();
+        console.log(
+          `[host] '${serverName}' provides ${toolsResult.tools.length} tool(s):`,
+        );
+        for (const tool of toolsResult.tools) {
+          console.log(`  - ${tool.name}: ${tool.description ?? "(no description)"}`);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.log(
+          `[host] Failed to connect to '${serverName}': ${message}`,
+        );
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  // 6. Load a skill with dependencies — triggers the callback
+  console.log(
+    '\n[host] Loading skill "explore-everything" (has dependencies)...\n',
+  );
+
+  try {
+    const content = await catalog.loadSkill("explore-everything");
+    console.log("[host] Skill loaded successfully!");
+    console.log("[host] Skill content preview:");
+    console.log(
+      content
+        .split("\n")
+        .slice(0, 10)
+        .map((l) => `  ${l}`)
+        .join("\n"),
+    );
+    console.log("  ...");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[host] Failed to load skill: ${message}`);
+  }
+
+  // 7. Summary
+  console.log("\n=== Summary ===");
+  console.log(`Skills discovered: ${catalog.skillNames.length}`);
+  console.log(`Servers dynamically connected: ${connectedServers.size}`);
+  for (const [name] of connectedServers) {
+    console.log(`  - ${name}`);
+  }
+
+  // Cleanup
+  console.log("\n[host] Cleaning up...");
+  for (const [name, client] of connectedServers) {
+    console.log(`[host] Disconnecting from '${name}'...`);
+    await client.close();
+  }
+  await skillClient.close();
+  console.log("[host] Done.");
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/examples/dynamic-server-loading/typescript/src/index.ts
+++ b/examples/dynamic-server-loading/typescript/src/index.ts
@@ -12,10 +12,14 @@
  * See: https://github.com/bradwilson/skillsdotnet/tree/main/samples/DynamicMcpServers
  */
 
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SkillCatalog } from "@ext-modelcontextprotocol/skills";
 import type { SkillDependencyRequest } from "@ext-modelcontextprotocol/skills";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // --- Configuration ---
 
@@ -55,7 +59,8 @@ async function main() {
   // Determine skill server path (the skills-as-resources example server)
   const skillServerDir =
     process.argv[2] ||
-    new URL("../../skills-as-resources/typescript", import.meta.url).pathname;
+    path.resolve(__dirname, "../../../skills-as-resources/typescript");
+  const skillsDir = path.resolve(__dirname, "../../../sample-skills");
 
   console.log("=== Dynamic MCP Server Loading Demo ===\n");
 
@@ -63,11 +68,7 @@ async function main() {
   console.log(`[host] Connecting to skill server: ${skillServerDir}`);
   const skillTransport = new StdioClientTransport({
     command: "node",
-    args: [
-      `${skillServerDir}/dist/index.js`,
-      "--skills-dir",
-      new URL("../../sample-skills", import.meta.url).pathname,
-    ],
+    args: [path.join(skillServerDir, "dist/index.js"), skillsDir],
   });
 
   const skillClient = new Client({

--- a/examples/dynamic-server-loading/typescript/tsconfig.json
+++ b/examples/dynamic-server-loading/typescript/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/sample-skills/explore-everything/SKILL.md
+++ b/examples/sample-skills/explore-everything/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: explore-everything
+description: Explore the MCP Everything Server to discover and demonstrate its tools
+dependencies: [everything-server]
+metadata:
+  author: skills-over-mcp-ig
+  version: "0.1"
+---
+
+# Explore Everything Server
+
+This skill requires the **Everything Server** MCP server to be connected.
+When loaded, the client host will automatically connect to it via the
+dependency resolution callback.
+
+## What to do
+
+1. Use the `echo` tool to validate connectivity to the Everything Server.
+2. List all available tools from the Everything Server and describe them to the user.
+3. Demonstrate at least one tool by calling it with sample inputs.
+
+## Notes
+
+- The Everything Server is an MCP reference server that exposes sample tools,
+  resources, and prompts for testing purposes.
+- If the expected tools are not available after loading this skill, it means
+  the server dependency was not connected. Ask the user to check their
+  server configuration.

--- a/examples/skills-as-resources/typescript/smoke-test.js
+++ b/examples/skills-as-resources/typescript/smoke-test.js
@@ -97,7 +97,7 @@ async function main() {
     });
 
     // Test 2: list resources
-    await runTest("List resources discovers both skills", async () => {
+    await runTest("List resources discovers all skills", async () => {
       const { resources } = await client.listResources();
       const uris = resources.map((r) => r.uri);
       assert(uris.includes("skill://prompt-xml"), "missing skill://prompt-xml");
@@ -118,8 +118,16 @@ async function main() {
         "missing git-commit-review _manifest",
       );
       assert(
-        resources.length >= 5,
-        `expected >= 5 resources, got ${resources.length}`,
+        uris.includes("skill://explore-everything/SKILL.md"),
+        "missing explore-everything SKILL.md",
+      );
+      assert(
+        uris.includes("skill://explore-everything/_manifest"),
+        "missing explore-everything _manifest",
+      );
+      assert(
+        resources.length >= 7,
+        `expected >= 7 resources, got ${resources.length}`,
       );
 
       const cr = resources.find(
@@ -150,6 +158,19 @@ async function main() {
       assert(
         px.annotations?.priority === 0.3,
         `prompt-xml priority: ${px.annotations?.priority}`,
+      );
+    });
+
+    // Test 2b: skill with dependencies has requirements in description
+    await runTest("Skill with dependencies shows requirements in description", async () => {
+      const { resources } = await client.listResources();
+      const ee = resources.find(
+        (r) => r.uri === "skill://explore-everything/SKILL.md",
+      );
+      assert(ee, "explore-everything resource not found");
+      assert(
+        ee.description?.includes("(requires: everything-server)"),
+        `expected '(requires: everything-server)' in description, got: ${ee.description}`,
       );
     });
 
@@ -264,8 +285,41 @@ async function main() {
         "missing git-commit-review in XML",
       );
       assert(
+        xml.includes("<name>explore-everything</name>"),
+        "missing explore-everything in XML",
+      );
+      assert(
         xml.includes("</available_skills>"),
         "missing </available_skills>",
+      );
+    });
+
+    // Test 8: read explore-everything SKILL.md (skill with dependencies)
+    await runTest("Read SKILL.md for skill with dependencies", async () => {
+      const res = await client.readResource({
+        uri: "skill://explore-everything/SKILL.md",
+      });
+      assert(
+        res.contents[0].text.includes("name: explore-everything"),
+        "missing name field",
+      );
+      assert(
+        res.contents[0].text.includes("dependencies: [everything-server]"),
+        "missing dependencies field in frontmatter",
+      );
+      assert(
+        res.contents[0].text.includes("# Explore Everything Server"),
+        "missing heading",
+      );
+    });
+
+    // Test 9: prompt-xml includes dependencies element
+    await runTest("Prompt XML includes dependencies for explore-everything", async () => {
+      const res = await client.readResource({ uri: "skill://prompt-xml" });
+      const xml = res.contents[0].text;
+      assert(
+        xml.includes("<dependencies>everything-server</dependencies>"),
+        "missing <dependencies> element in XML for explore-everything",
       );
     });
 

--- a/typescript/sdk/src/catalog.test.ts
+++ b/typescript/sdk/src/catalog.test.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SkillCatalog } from "./catalog.js";
+import type { SkillDependencyRequest } from "./types.js";
+
+// --- Mock client factory ---
+
+function makeSkillContent(
+  name: string,
+  description: string,
+  dependencies?: string[],
+): string {
+  const depsLine = dependencies
+    ? `\ndependencies: [${dependencies.join(", ")}]`
+    : "";
+  return `---\nname: ${name}\ndescription: ${description}${depsLine}\n---\n# ${name}\nBody content for ${name}.`;
+}
+
+function makeMockClient(
+  skills: Array<{
+    name: string;
+    description: string;
+    dependencies?: string[];
+  }>,
+) {
+  const resources = skills.map((s) => {
+    const desc = s.dependencies
+      ? `${s.description} (requires: ${s.dependencies.join(", ")})`
+      : s.description;
+    return {
+      uri: `skill://${s.name}/SKILL.md`,
+      name: s.name,
+      description: desc,
+      mimeType: "text/markdown",
+    };
+  });
+
+  const contentMap = new Map<string, string>();
+  for (const s of skills) {
+    contentMap.set(
+      `skill://${s.name}/SKILL.md`,
+      makeSkillContent(s.name, s.description, s.dependencies),
+    );
+  }
+
+  return {
+    listResources: vi.fn().mockResolvedValue({ resources }),
+    readResource: vi.fn().mockImplementation(({ uri }: { uri: string }) => {
+      const text = contentMap.get(uri);
+      if (!text) throw new Error(`Not found: ${uri}`);
+      return Promise.resolve({ contents: [{ uri, text }] });
+    }),
+  };
+}
+
+type MockClient = ReturnType<typeof makeMockClient>;
+
+// --- Tests ---
+
+describe("SkillCatalog", () => {
+  describe("constructor", () => {
+    it("creates an empty catalog", () => {
+      const catalog = new SkillCatalog();
+      expect(catalog.skillNames).toEqual([]);
+      expect(catalog.getSkillContexts()).toEqual([]);
+      expect(catalog.onDependenciesRequired).toBeUndefined();
+    });
+  });
+
+  describe("create factory", () => {
+    it("creates a catalog pre-populated from a client", async () => {
+      const client = makeMockClient([
+        { name: "skill-a", description: "Skill A" },
+        { name: "skill-b", description: "Skill B" },
+      ]);
+
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+
+      expect(catalog.skillNames).toHaveLength(2);
+      expect(catalog.skillNames).toContain("skill-a");
+      expect(catalog.skillNames).toContain("skill-b");
+    });
+  });
+
+  describe("addClient", () => {
+    let catalog: SkillCatalog;
+
+    beforeEach(() => {
+      catalog = new SkillCatalog();
+    });
+
+    it("discovers skills and caches them", async () => {
+      const client = makeMockClient([
+        { name: "code-review", description: "Review code" },
+      ]);
+
+      await catalog.addClient(
+        client as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+
+      expect(catalog.skillNames).toEqual(["code-review"]);
+      expect(client.listResources).toHaveBeenCalledTimes(1);
+      expect(client.readResource).toHaveBeenCalledTimes(1);
+    });
+
+    it("discovers skills with dependencies", async () => {
+      const client = makeMockClient([
+        {
+          name: "explore-everything",
+          description: "Explore the Everything Server",
+          dependencies: ["everything-server"],
+        },
+      ]);
+
+      await catalog.addClient(
+        client as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+
+      expect(catalog.skillNames).toEqual(["explore-everything"]);
+      const context = catalog.getSkillContext("explore-everything");
+      expect(context).toContain("explore-everything");
+      expect(context).toContain("requires: everything-server");
+    });
+
+    it("overwrites skill from a different client with same name", async () => {
+      const client1 = makeMockClient([
+        { name: "shared", description: "Version 1" },
+      ]);
+      const client2 = makeMockClient([
+        { name: "shared", description: "Version 2" },
+      ]);
+
+      await catalog.addClient(
+        client1 as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+      await catalog.addClient(
+        client2 as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+
+      expect(catalog.skillNames).toEqual(["shared"]);
+      const context = catalog.getSkillContext("shared");
+      expect(context).toContain("Version 2");
+    });
+
+    it("adds skills from multiple clients", async () => {
+      const client1 = makeMockClient([
+        { name: "skill-a", description: "From client 1" },
+      ]);
+      const client2 = makeMockClient([
+        { name: "skill-b", description: "From client 2" },
+      ]);
+
+      await catalog.addClient(
+        client1 as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+      await catalog.addClient(
+        client2 as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+
+      expect(catalog.skillNames).toHaveLength(2);
+      expect(catalog.skillNames).toContain("skill-a");
+      expect(catalog.skillNames).toContain("skill-b");
+    });
+  });
+
+  describe("removeClient", () => {
+    it("removes all skills from a specific client", async () => {
+      const catalog = new SkillCatalog();
+      const client1 = makeMockClient([
+        { name: "skill-a", description: "From client 1" },
+      ]);
+      const client2 = makeMockClient([
+        { name: "skill-b", description: "From client 2" },
+      ]);
+
+      await catalog.addClient(
+        client1 as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+      await catalog.addClient(
+        client2 as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+
+      catalog.removeClient(
+        client1 as unknown as Parameters<typeof catalog.removeClient>[0],
+      );
+
+      expect(catalog.skillNames).toEqual(["skill-b"]);
+    });
+
+    it("is a no-op for unknown client", () => {
+      const catalog = new SkillCatalog();
+      const unknownClient = makeMockClient([]);
+
+      // Should not throw
+      catalog.removeClient(
+        unknownClient as unknown as Parameters<typeof catalog.removeClient>[0],
+      );
+      expect(catalog.skillNames).toEqual([]);
+    });
+  });
+
+  describe("getSkillContext", () => {
+    it("returns context string for a known skill", async () => {
+      const client = makeMockClient([
+        { name: "code-review", description: "Review code" },
+      ]);
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+
+      const context = catalog.getSkillContext("code-review");
+      expect(context).toBe("[skill: code-review] Review code");
+    });
+
+    it("includes dependencies in context string", async () => {
+      const client = makeMockClient([
+        {
+          name: "explore",
+          description: "Explore servers",
+          dependencies: ["server-a", "server-b"],
+        },
+      ]);
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+
+      const context = catalog.getSkillContext("explore");
+      expect(context).toBe(
+        "[skill: explore] Explore servers (requires: server-a, server-b)",
+      );
+    });
+
+    it("throws for unknown skill name", () => {
+      const catalog = new SkillCatalog();
+      expect(() => catalog.getSkillContext("nonexistent")).toThrow(
+        "Skill 'nonexistent' not found in catalog.",
+      );
+    });
+  });
+
+  describe("getSkillContexts", () => {
+    it("returns empty array for empty catalog", () => {
+      const catalog = new SkillCatalog();
+      expect(catalog.getSkillContexts()).toEqual([]);
+    });
+
+    it("returns all context strings", async () => {
+      const client = makeMockClient([
+        { name: "skill-a", description: "A" },
+        { name: "skill-b", description: "B" },
+      ]);
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+
+      const contexts = catalog.getSkillContexts();
+      expect(contexts).toHaveLength(2);
+      expect(contexts).toContain("[skill: skill-a] A");
+      expect(contexts).toContain("[skill: skill-b] B");
+    });
+  });
+
+  describe("custom context formatter", () => {
+    it("uses a custom formatter when provided", async () => {
+      const client = makeMockClient([
+        { name: "my-skill", description: "My description" },
+      ]);
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+        (fm) => `CUSTOM: ${fm.name}`,
+      );
+
+      expect(catalog.getSkillContext("my-skill")).toBe("CUSTOM: my-skill");
+    });
+  });
+
+  describe("loadSkill", () => {
+    it("loads skill content from the originating client", async () => {
+      const client = makeMockClient([
+        { name: "code-review", description: "Review code" },
+      ]);
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+
+      const content = await catalog.loadSkill("code-review");
+      expect(content).toContain("name: code-review");
+      expect(content).toContain("Body content for code-review.");
+    });
+
+    it("throws for unknown skill name", async () => {
+      const catalog = new SkillCatalog();
+      await expect(catalog.loadSkill("nonexistent")).rejects.toThrow(
+        "Skill 'nonexistent' not found in catalog.",
+      );
+    });
+
+    it("loads skill without dependencies and no callback", async () => {
+      const client = makeMockClient([
+        { name: "simple", description: "Simple skill" },
+      ]);
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+
+      // No callback set, no dependencies — should work fine
+      const content = await catalog.loadSkill("simple");
+      expect(content).toContain("name: simple");
+    });
+
+    it("loads skill with dependencies silently when no callback set", async () => {
+      const client = makeMockClient([
+        {
+          name: "has-deps",
+          description: "Has deps",
+          dependencies: ["some-server"],
+        },
+      ]);
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+
+      // No callback — should load silently
+      const content = await catalog.loadSkill("has-deps");
+      expect(content).toContain("name: has-deps");
+    });
+  });
+
+  describe("onDependenciesRequired callback", () => {
+    let catalog: SkillCatalog;
+    let client: MockClient;
+
+    beforeEach(async () => {
+      client = makeMockClient([
+        {
+          name: "with-deps",
+          description: "Skill with deps",
+          dependencies: ["server-a", "server-b"],
+        },
+        { name: "no-deps", description: "Skill without deps" },
+      ]);
+      catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+    });
+
+    it("fires callback when loading skill with dependencies", async () => {
+      const callback = vi.fn().mockResolvedValue(true);
+      catalog.onDependenciesRequired = callback;
+
+      await catalog.loadSkill("with-deps");
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const request: SkillDependencyRequest = callback.mock.calls[0][0];
+      expect(request.skillName).toBe("with-deps");
+      expect(request.serverNames).toEqual(["server-a", "server-b"]);
+    });
+
+    it("does not fire callback for skill without dependencies", async () => {
+      const callback = vi.fn().mockResolvedValue(true);
+      catalog.onDependenciesRequired = callback;
+
+      await catalog.loadSkill("no-deps");
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("throws when callback returns false", async () => {
+      catalog.onDependenciesRequired = vi.fn().mockResolvedValue(false);
+
+      await expect(catalog.loadSkill("with-deps")).rejects.toThrow(
+        "required MCP server dependencies could not be satisfied",
+      );
+    });
+
+    it("succeeds when callback returns true", async () => {
+      catalog.onDependenciesRequired = vi.fn().mockResolvedValue(true);
+
+      const content = await catalog.loadSkill("with-deps");
+      expect(content).toContain("name: with-deps");
+    });
+
+    it("can be set to undefined to disable", async () => {
+      catalog.onDependenciesRequired = vi.fn().mockResolvedValue(true);
+      catalog.onDependenciesRequired = undefined;
+
+      // Should load silently without firing callback
+      const content = await catalog.loadSkill("with-deps");
+      expect(content).toContain("name: with-deps");
+    });
+  });
+
+  describe("getLoadSkillToolDefinition", () => {
+    it("returns correct schema for empty catalog", () => {
+      const catalog = new SkillCatalog();
+      const tool = catalog.getLoadSkillToolDefinition();
+
+      expect(tool.name).toBe("load_skill");
+      expect(tool.description).toContain("Available skills:");
+      expect(tool.inputSchema).toEqual({
+        type: "object",
+        properties: {
+          skillName: {
+            type: "string",
+            description: "The name of the skill to load",
+            enum: [],
+          },
+        },
+        required: ["skillName"],
+      });
+    });
+
+    it("includes all skill names in enum", async () => {
+      const client = makeMockClient([
+        { name: "skill-a", description: "A" },
+        { name: "skill-b", description: "B" },
+      ]);
+      const catalog = await SkillCatalog.create(
+        client as unknown as Parameters<typeof SkillCatalog.create>[0],
+      );
+
+      const tool = catalog.getLoadSkillToolDefinition();
+      expect(tool.description).toContain("skill-a, skill-b");
+      const schema = tool.inputSchema as {
+        properties: { skillName: { enum: string[] } };
+      };
+      expect(schema.properties.skillName.enum).toEqual([
+        "skill-a",
+        "skill-b",
+      ]);
+    });
+
+    it("reflects current state after removeClient", async () => {
+      const client1 = makeMockClient([
+        { name: "skill-a", description: "A" },
+      ]);
+      const client2 = makeMockClient([
+        { name: "skill-b", description: "B" },
+      ]);
+      const catalog = new SkillCatalog();
+      await catalog.addClient(
+        client1 as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+      await catalog.addClient(
+        client2 as unknown as Parameters<typeof catalog.addClient>[0],
+      );
+
+      catalog.removeClient(
+        client1 as unknown as Parameters<typeof catalog.removeClient>[0],
+      );
+
+      const tool = catalog.getLoadSkillToolDefinition();
+      const schema = tool.inputSchema as {
+        properties: { skillName: { enum: string[] } };
+      };
+      expect(schema.properties.skillName.enum).toEqual(["skill-b"]);
+    });
+  });
+});

--- a/typescript/sdk/src/catalog.ts
+++ b/typescript/sdk/src/catalog.ts
@@ -1,0 +1,226 @@
+/**
+ * Client-side skill catalog with on-demand dependency resolution.
+ *
+ * Discovers skills from one or more MCP servers, caches their frontmatter
+ * as lightweight context strings, and exposes a load_skill tool definition
+ * for on-demand skill loading. When a skill with MCP server dependencies
+ * is loaded, the onDependenciesRequired callback fires so the host can
+ * connect required servers dynamically.
+ *
+ * Port of SkillsDotNet.Mcp.SkillCatalog (C#) to TypeScript.
+ */
+
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { SkillSummary, SkillDependencyRequest } from "./types.js";
+import { listSkillResources, parseSkillFrontmatter } from "./client.js";
+
+/**
+ * Internal cache entry for a discovered skill.
+ */
+interface CachedSkill {
+  client: Client;
+  resourceUri: string;
+  summary: SkillSummary;
+  context: string;
+  dependencies: string[];
+}
+
+/**
+ * Formatter function for generating context strings from skill frontmatter.
+ * Receives the parsed frontmatter fields and returns a text representation
+ * suitable for injection into a system prompt (~50-100 tokens per skill).
+ */
+export type ContextFormatter = (frontmatter: {
+  name: string;
+  description: string;
+  dependencies?: string[];
+}) => string;
+
+/**
+ * Default context formatter — matches skillsdotnet's DefaultFormatter pattern.
+ */
+function defaultFormatter(frontmatter: {
+  name: string;
+  description: string;
+  dependencies?: string[];
+}): string {
+  let text = `[skill: ${frontmatter.name}] ${frontmatter.description}`;
+  if (frontmatter.dependencies && frontmatter.dependencies.length > 0) {
+    text += ` (requires: ${frontmatter.dependencies.join(", ")})`;
+  }
+  return text;
+}
+
+/**
+ * Client-side service that discovers skills from one or more MCP servers,
+ * caches their frontmatter as lightweight context strings, and exposes
+ * a load_skill tool for on-demand skill loading with dependency resolution.
+ */
+export class SkillCatalog {
+  private readonly _cache = new Map<string, CachedSkill>();
+  private readonly _contextFormatter: ContextFormatter;
+
+  constructor(contextFormatter?: ContextFormatter) {
+    this._contextFormatter = contextFormatter ?? defaultFormatter;
+  }
+
+  /**
+   * Convenience factory that creates a catalog pre-populated from a single client.
+   */
+  static async create(
+    client: Client,
+    contextFormatter?: ContextFormatter,
+  ): Promise<SkillCatalog> {
+    const catalog = new SkillCatalog(contextFormatter);
+    await catalog.addClient(client);
+    return catalog;
+  }
+
+  /**
+   * Discovers skills from the given client, reads each skill's SKILL.md,
+   * parses frontmatter, and adds them to the catalog.
+   * If a skill name already exists from a different client, it is overwritten.
+   */
+  async addClient(client: Client): Promise<void> {
+    const skills = await listSkillResources(client);
+
+    for (const skill of skills) {
+      const result = await client.readResource({ uri: skill.uri });
+      const content = result.contents[0];
+      if (!content || !("text" in content)) continue;
+
+      const parsed = parseSkillFrontmatter(content.text);
+      if (!parsed) continue;
+
+      const dependencies = parsed.dependencies ?? skill.dependencies ?? [];
+      const context = this._contextFormatter({
+        name: parsed.name,
+        description: parsed.description,
+        dependencies: dependencies.length > 0 ? dependencies : undefined,
+      });
+
+      this._cache.set(parsed.name, {
+        client,
+        resourceUri: skill.uri,
+        summary: { ...skill, dependencies },
+        context,
+        dependencies,
+      });
+    }
+  }
+
+  /**
+   * Removes all skills that were discovered from the given client.
+   */
+  removeClient(client: Client): void {
+    for (const [name, cached] of this._cache) {
+      if (cached.client === client) {
+        this._cache.delete(name);
+      }
+    }
+  }
+
+  /**
+   * Names of all discovered skills.
+   */
+  get skillNames(): string[] {
+    return Array.from(this._cache.keys());
+  }
+
+  /**
+   * Returns the cached context string for the given skill.
+   * @throws Error if the skill name is not in the catalog.
+   */
+  getSkillContext(skillName: string): string {
+    const cached = this._cache.get(skillName);
+    if (!cached) {
+      throw new Error(`Skill '${skillName}' not found in catalog.`);
+    }
+    return cached.context;
+  }
+
+  /**
+   * Returns context strings for all discovered skills.
+   */
+  getSkillContexts(): string[] {
+    return Array.from(this._cache.values()).map((c) => c.context);
+  }
+
+  /**
+   * Optional callback invoked when a skill with MCP server dependencies is loaded.
+   * Return true if all servers are connected, false if any could not be connected.
+   * When false is returned, loadSkill() throws an error.
+   * If not set, skills with dependencies load silently without notification.
+   */
+  onDependenciesRequired?:
+    | ((request: SkillDependencyRequest) => Promise<boolean>)
+    | undefined;
+
+  /**
+   * Reads the full SKILL.md content for the given skill from its originating MCP server.
+   * If the skill has dependencies and onDependenciesRequired is set, fires the callback first.
+   *
+   * @throws Error if the skill name is not found.
+   * @throws Error if onDependenciesRequired returns false.
+   */
+  async loadSkill(skillName: string): Promise<string> {
+    const cached = this._cache.get(skillName);
+    if (!cached) {
+      throw new Error(`Skill '${skillName}' not found in catalog.`);
+    }
+
+    if (cached.dependencies.length > 0 && this.onDependenciesRequired) {
+      const request: SkillDependencyRequest = {
+        skillName,
+        serverNames: cached.dependencies,
+      };
+
+      const connected = await this.onDependenciesRequired(request);
+      if (!connected) {
+        throw new Error(
+          `Cannot load skill '${skillName}': required MCP server dependencies could not be satisfied.`,
+        );
+      }
+    }
+
+    const result = await cached.client.readResource({
+      uri: cached.resourceUri,
+    });
+    const content = result.contents[0];
+    if (!content || !("text" in content)) {
+      throw new Error(`No text content returned for skill '${skillName}'.`);
+    }
+
+    return content.text;
+  }
+
+  /**
+   * Returns an MCP-compatible tool definition for the load_skill tool.
+   * The description lists all available skill names, and the inputSchema
+   * constrains the skillName parameter to an enum of known names.
+   *
+   * Rebuilt dynamically from the current cache state on each call.
+   */
+  getLoadSkillToolDefinition(): {
+    name: string;
+    description: string;
+    inputSchema: object;
+  } {
+    const names = Array.from(this._cache.keys());
+    return {
+      name: "load_skill",
+      description: `Load the full content of a skill by name. Available skills: ${names.join(", ")}`,
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          skillName: {
+            type: "string" as const,
+            description: "The name of the skill to load",
+            enum: names,
+          },
+        },
+        required: ["skillName"],
+      },
+    };
+  }
+}

--- a/typescript/sdk/src/client.test.ts
+++ b/typescript/sdk/src/client.test.ts
@@ -80,6 +80,69 @@ Body
       description: "Extended skill",
     });
   });
+
+  it("parses dependencies from frontmatter", () => {
+    const content = `---
+name: with-deps
+description: Has dependencies
+dependencies: [server-a, server-b]
+---
+Body
+`;
+    const result = parseSkillFrontmatter(content);
+    expect(result).toEqual({
+      name: "with-deps",
+      description: "Has dependencies",
+      dependencies: ["server-a", "server-b"],
+    });
+  });
+
+  it("parses single dependency", () => {
+    const content = `---
+name: single-dep
+description: One dependency
+dependencies: [everything-server]
+---
+Body
+`;
+    const result = parseSkillFrontmatter(content);
+    expect(result?.dependencies).toEqual(["everything-server"]);
+  });
+
+  it("parses quoted dependency values", () => {
+    const content = `---
+name: quoted-deps
+description: Quoted deps
+dependencies: ["server-a", 'server-b']
+---
+Body
+`;
+    const result = parseSkillFrontmatter(content);
+    expect(result?.dependencies).toEqual(["server-a", "server-b"]);
+  });
+
+  it("returns undefined dependencies when field is absent", () => {
+    const content = `---
+name: no-deps
+description: No dependencies
+---
+Body
+`;
+    const result = parseSkillFrontmatter(content);
+    expect(result?.dependencies).toBeUndefined();
+  });
+
+  it("handles empty dependencies list", () => {
+    const content = `---
+name: empty-deps
+description: Empty deps
+dependencies: []
+---
+Body
+`;
+    const result = parseSkillFrontmatter(content);
+    expect(result?.dependencies).toBeUndefined();
+  });
 });
 
 describe("buildSkillsSummary", () => {
@@ -120,6 +183,20 @@ describe("buildSkillsSummary", () => {
     const lines = result.split("\n");
     // The skill line should NOT end with ": description" — just the URI
     expect(lines[1]).toBe("- basic (skill://basic/SKILL.md)");
+  });
+
+  it("includes dependencies in summary", () => {
+    const skills: SkillSummary[] = [
+      {
+        name: "explore",
+        uri: "skill://explore/SKILL.md",
+        description: "Explore servers",
+        dependencies: ["server-a", "server-b"],
+      },
+    ];
+
+    const result = buildSkillsSummary(skills);
+    expect(result).toContain("[requires: server-a, server-b]");
   });
 });
 
@@ -219,5 +296,70 @@ describe("listSkillResources", () => {
     );
 
     expect(skills).toHaveLength(0);
+  });
+
+  it("parses dependencies from resource description", async () => {
+    const mockClient = {
+      listResources: vi.fn().mockResolvedValue({
+        resources: [
+          {
+            uri: "skill://explore/SKILL.md",
+            name: "explore",
+            description:
+              "Explore the Everything Server (requires: everything-server)",
+            mimeType: "text/markdown",
+          },
+        ],
+      }),
+    };
+
+    const skills = await listSkillResources(
+      mockClient as unknown as Parameters<typeof listSkillResources>[0],
+    );
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].dependencies).toEqual(["everything-server"]);
+    expect(skills[0].description).toBe("Explore the Everything Server");
+  });
+
+  it("parses multiple dependencies from resource description", async () => {
+    const mockClient = {
+      listResources: vi.fn().mockResolvedValue({
+        resources: [
+          {
+            uri: "skill://multi/SKILL.md",
+            name: "multi",
+            description: "Multi deps (requires: server-a, server-b)",
+          },
+        ],
+      }),
+    };
+
+    const skills = await listSkillResources(
+      mockClient as unknown as Parameters<typeof listSkillResources>[0],
+    );
+
+    expect(skills[0].dependencies).toEqual(["server-a", "server-b"]);
+    expect(skills[0].description).toBe("Multi deps");
+  });
+
+  it("returns no dependencies when description has no requires suffix", async () => {
+    const mockClient = {
+      listResources: vi.fn().mockResolvedValue({
+        resources: [
+          {
+            uri: "skill://simple/SKILL.md",
+            name: "simple",
+            description: "A simple skill",
+          },
+        ],
+      }),
+    };
+
+    const skills = await listSkillResources(
+      mockClient as unknown as Parameters<typeof listSkillResources>[0],
+    );
+
+    expect(skills[0].dependencies).toBeUndefined();
   });
 });

--- a/typescript/sdk/src/client.ts
+++ b/typescript/sdk/src/client.ts
@@ -33,11 +33,26 @@ export async function listSkillResources(
       const parsed = parseSkillUri(resource.uri);
       if (!parsed || parsed.path !== SKILL_FILENAME) continue;
 
+      // Parse dependencies from "(requires: a, b)" suffix in description
+      let description = resource.description;
+      let dependencies: string[] | undefined;
+      if (description) {
+        const reqMatch = description.match(/\s*\(requires:\s*(.+)\)$/);
+        if (reqMatch) {
+          dependencies = reqMatch[1]
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+          description = description.slice(0, reqMatch.index);
+        }
+      }
+
       skills.push({
         name: parsed.name,
         uri: resource.uri,
-        description: resource.description,
+        description,
         mimeType: resource.mimeType,
+        dependencies,
       });
     }
 
@@ -57,7 +72,7 @@ export async function listSkillResources(
  */
 export function parseSkillFrontmatter(
   content: string,
-): { name: string; description: string } | null {
+): { name: string; description: string; dependencies?: string[] } | null {
   if (!content.startsWith("---")) return null;
 
   const endIndex = content.indexOf("---", 3);
@@ -75,7 +90,20 @@ export function parseSkillFrontmatter(
     ? descMatch[1].trim().replace(/^["']|["']$/g, "")
     : "";
 
-  return { name, description };
+  // Parse optional dependencies: [server-a, server-b]
+  let dependencies: string[] | undefined;
+  const depsMatch = frontmatter.match(/^dependencies:\s*\[([^\]]*)\]$/m);
+  if (depsMatch) {
+    const items = depsMatch[1]
+      .split(",")
+      .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+      .filter((s) => s.length > 0);
+    if (items.length > 0) {
+      dependencies = items;
+    }
+  }
+
+  return { name, description, dependencies };
 }
 
 /**
@@ -94,7 +122,11 @@ export function buildSkillsSummary(skills: SkillSummary[]): string {
   const lines = ["Available skills:"];
   for (const skill of skills) {
     const desc = skill.description ? `: ${skill.description}` : "";
-    lines.push(`- ${skill.name} (${skill.uri})${desc}`);
+    const deps =
+      skill.dependencies && skill.dependencies.length > 0
+        ? ` [requires: ${skill.dependencies.join(", ")}]`
+        : "";
+    lines.push(`- ${skill.name} (${skill.uri})${desc}${deps}`);
   }
   return lines.join("\n");
 }

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -13,6 +13,7 @@ export type {
   SkillDocument,
   SkillMetadata,
   SkillSummary,
+  SkillDependencyRequest,
   RegisterSkillResourcesOptions,
   SkillResourceHandles,
 } from "./types.js";
@@ -53,3 +54,7 @@ export {
   parseSkillFrontmatter,
   buildSkillsSummary,
 } from "./client.js";
+
+// Skill catalog with dependency resolution
+export { SkillCatalog } from "./catalog.js";
+export type { ContextFormatter } from "./catalog.js";

--- a/typescript/sdk/src/server.test.ts
+++ b/typescript/sdk/src/server.test.ts
@@ -142,6 +142,67 @@ describe("discoverSkills", () => {
     const skill = skills.get("meta-skill")!;
     expect(skill.metadata).toEqual({ author: "test", version: "1.0" });
   });
+
+  it("extracts dependencies from frontmatter", () => {
+    const skillDir = path.join(tmpDir, "dep-skill");
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: dep-skill\ndescription: Has deps\ndependencies: [server-a, server-b]\n---\n# Dep",
+    );
+
+    const skills = discoverSkills(tmpDir);
+    const skill = skills.get("dep-skill")!;
+    expect(skill.dependencies).toEqual(["server-a", "server-b"]);
+  });
+
+  it("extracts single dependency", () => {
+    const skillDir = path.join(tmpDir, "single-dep");
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: single-dep\ndescription: One dep\ndependencies: [everything-server]\n---\n# Single",
+    );
+
+    const skills = discoverSkills(tmpDir);
+    const skill = skills.get("single-dep")!;
+    expect(skill.dependencies).toEqual(["everything-server"]);
+  });
+
+  it("returns undefined dependencies when field is absent", () => {
+    createSkill("no-deps", "No deps");
+
+    const skills = discoverSkills(tmpDir);
+    const skill = skills.get("no-deps")!;
+    expect(skill.dependencies).toBeUndefined();
+  });
+
+  it("ignores non-array dependencies", () => {
+    const skillDir = path.join(tmpDir, "bad-deps");
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: bad-deps\ndescription: Bad deps\ndependencies: not-an-array\n---\n# Bad",
+    );
+
+    const skills = discoverSkills(tmpDir);
+    const skill = skills.get("bad-deps")!;
+    expect(skill.dependencies).toBeUndefined();
+  });
+
+  it("filters non-string items from dependencies", () => {
+    const skillDir = path.join(tmpDir, "mixed-deps");
+    fs.mkdirSync(skillDir);
+    fs.writeFileSync(
+      path.join(skillDir, "SKILL.md"),
+      "---\nname: mixed-deps\ndescription: Mixed\ndependencies: [valid-server, 123, '', another-server]\n---\n# Mixed",
+    );
+
+    const skills = discoverSkills(tmpDir);
+    const skill = skills.get("mixed-deps")!;
+    // 123 is parsed as number by YAML, '' is empty — both filtered out
+    expect(skill.dependencies).toEqual(["valid-server", "another-server"]);
+  });
 });
 
 describe("loadSkillContent", () => {

--- a/typescript/sdk/src/server.ts
+++ b/typescript/sdk/src/server.ts
@@ -270,6 +270,17 @@ export function discoverSkills(
         }
       }
 
+      // Extract optional MCP server dependencies
+      let dependencies: string[] | undefined;
+      if (Array.isArray(frontmatter.dependencies)) {
+        const valid = frontmatter.dependencies.filter(
+          (d): d is string => typeof d === "string" && d.trim().length > 0,
+        );
+        if (valid.length > 0) {
+          dependencies = valid.map((d) => d.trim());
+        }
+      }
+
       const trimmedName = name.trim();
       if (skillMap.has(trimmedName)) {
         console.error(
@@ -302,6 +313,7 @@ export function discoverSkills(
         path: skillMdPath,
         skillDir,
         metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+        dependencies,
         documents,
         manifest,
         manifestJson,
@@ -408,11 +420,17 @@ export function registerSkillResources(
 
   // Register per-skill resources
   for (const [name, skill] of skillMap) {
+    // Append dependency info to description so clients can see it via resources/list
+    const skillDescription =
+      skill.dependencies && skill.dependencies.length > 0
+        ? `${skill.description} (requires: ${skill.dependencies.join(", ")})`
+        : skill.description;
+
     const skillHandle = server.registerResource(
       `skill-${name}`,
       `skill://${name}/SKILL.md`,
       {
-        description: skill.description,
+        description: skillDescription,
         mimeType: "text/markdown",
         annotations: {
           audience: ["user", "assistant"],

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -62,6 +62,7 @@ export interface SkillMetadata {
   path: string; // Absolute path to the SKILL.md file
   skillDir: string; // Absolute path to the skill's directory
   metadata?: Record<string, string>; // Optional extra frontmatter fields
+  dependencies?: string[]; // MCP server dependencies declared in frontmatter
   documents: SkillDocument[]; // Supplementary files found in subdirectories
   manifest: SkillManifest; // Pre-computed file manifest
   manifestJson: string; // Pre-serialized manifest JSON (avoids I/O on request)
@@ -81,6 +82,21 @@ export interface SkillSummary {
   description?: string;
   /** MIME type of the resource */
   mimeType?: string;
+  /** MCP server dependencies (parsed from resource description or frontmatter) */
+  dependencies?: string[];
+}
+
+/**
+ * Describes the MCP server dependencies required by a skill being loaded.
+ * Passed to the SkillCatalog's onDependenciesRequired callback.
+ *
+ * Aligned with SkillsDotNet.Mcp.SkillDependencyRequest.
+ */
+export interface SkillDependencyRequest {
+  /** The name of the skill being loaded */
+  skillName: string;
+  /** The MCP server names declared in the skill's dependencies frontmatter field */
+  serverNames: string[];
 }
 
 /**

--- a/typescript/sdk/src/xml.test.ts
+++ b/typescript/sdk/src/xml.test.ts
@@ -29,12 +29,14 @@ describe("escapeXml", () => {
 function makeSkillMetadata(
   name: string,
   description: string,
+  dependencies?: string[],
 ): SkillMetadata {
   return {
     name,
     description,
     path: `/skills/${name}/SKILL.md`,
     skillDir: `/skills/${name}`,
+    dependencies,
     documents: [],
     manifest: { skill: name, files: [] },
     manifestJson: "{}",
@@ -87,6 +89,27 @@ describe("generateSkillsXML", () => {
       "A &quot;skill&quot; with &lt;tags&gt; &amp; more",
     );
   });
+
+  it("includes dependencies element when present", () => {
+    const map = new Map<string, SkillMetadata>();
+    map.set(
+      "with-deps",
+      makeSkillMetadata("with-deps", "Has deps", ["server-a", "server-b"]),
+    );
+
+    const result = generateSkillsXML(map);
+    expect(result).toContain(
+      "<dependencies>server-a, server-b</dependencies>",
+    );
+  });
+
+  it("omits dependencies element when absent", () => {
+    const map = new Map<string, SkillMetadata>();
+    map.set("no-deps", makeSkillMetadata("no-deps", "No deps"));
+
+    const result = generateSkillsXML(map);
+    expect(result).not.toContain("<dependencies>");
+  });
 });
 
 describe("generateSkillsXMLFromSummaries", () => {
@@ -126,5 +149,34 @@ describe("generateSkillsXMLFromSummaries", () => {
     expect(result).toContain("<name>basic</name>");
     expect(result).not.toContain("<description>");
     expect(result).toContain("<uri>skill://basic/SKILL.md</uri>");
+  });
+
+  it("includes dependencies in summary XML when present", () => {
+    const skills: SkillSummary[] = [
+      {
+        name: "explore",
+        uri: "skill://explore/SKILL.md",
+        description: "Explore",
+        dependencies: ["everything-server"],
+      },
+    ];
+
+    const result = generateSkillsXMLFromSummaries(skills);
+    expect(result).toContain(
+      "<dependencies>everything-server</dependencies>",
+    );
+  });
+
+  it("omits dependencies in summary XML when absent", () => {
+    const skills: SkillSummary[] = [
+      {
+        name: "simple",
+        uri: "skill://simple/SKILL.md",
+        description: "Simple",
+      },
+    ];
+
+    const result = generateSkillsXMLFromSummaries(skills);
+    expect(result).not.toContain("<dependencies>");
   });
 });

--- a/typescript/sdk/src/xml.ts
+++ b/typescript/sdk/src/xml.ts
@@ -48,6 +48,11 @@ export function generateSkillsXML(
       `    <description>${escapeXml(skill.description)}</description>`,
     );
     lines.push(`    <uri>skill://${escapeXml(skill.name)}/SKILL.md</uri>`);
+    if (skill.dependencies && skill.dependencies.length > 0) {
+      lines.push(
+        `    <dependencies>${skill.dependencies.map((d) => escapeXml(d)).join(", ")}</dependencies>`,
+      );
+    }
     lines.push("  </skill>");
   }
 
@@ -75,6 +80,11 @@ export function generateSkillsXMLFromSummaries(
       );
     }
     lines.push(`    <uri>${escapeXml(skill.uri)}</uri>`);
+    if (skill.dependencies && skill.dependencies.length > 0) {
+      lines.push(
+        `    <dependencies>${skill.dependencies.map((d) => escapeXml(d)).join(", ")}</dependencies>`,
+      );
+    }
     lines.push("  </skill>");
   }
 


### PR DESCRIPTION
## Summary

- Demonstrates declaring MCP server dependencies in YAML frontmatter (`dependencies: [server-name]`)
- New `SkillCatalog` class (TypeScript port of [skillsdotnet's SkillCatalog](https://github.com/bradwilson/skillsdotnet)) discovers skills, caches frontmatter context, and fires an `onDependenciesRequired` callback when loading a skill with dependencies — enabling the host to connect required servers on demand
- Server-side: `discoverSkills()` parses dependencies, resource descriptions include `(requires: ...)` suffix
- Client-side: `parseSkillFrontmatter()` and `listSkillResources()` extract dependencies; `buildSkillsSummary()` and XML generators include dependency info

### New files
- `typescript/sdk/src/catalog.ts` — `SkillCatalog` with `addClient`, `removeClient`, `loadSkill`, `onDependenciesRequired`, `getLoadSkillToolDefinition`
- `examples/sample-skills/explore-everything/SKILL.md` — sample skill with `dependencies: [everything-server]`
- `examples/dynamic-server-loading/typescript/` — end-to-end demo (TypeScript port of skillsdotnet's DynamicMcpServers sample)

## Test plan

- [x] 106 unit tests passing (44 new) — catalog, dependency parsing, XML generation
- [x] 10 smoke tests passing (3 new) — dependency metadata in resources/list, descriptions, XML
- [x] End-to-end verified: skill server → SkillCatalog → `onDependenciesRequired` callback → dynamically connects `@modelcontextprotocol/server-everything` via npx → 11 tools discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored with @PederHP (skillsdotnet) 